### PR TITLE
Allow landscape orientation

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -31,7 +31,6 @@
   "start_url": "/?homescreen=1",
   "scope": "/",
   "display": "standalone",
-  "orientation": "portrait",
   "background_color": "#2196F3",
   "theme_color": "#2196F3"
 }


### PR DESCRIPTION
Allow landscape orientation. Useful for large screen devices e.g. phablets and tablets.