### PR TITLE
Fix WebAudio playback due to autoplay policy changes

### DIFF
--- a/app/scripts/main.min.js
+++ b/app/scripts/main.min.js
@@ -77,6 +77,9 @@
         return;
       }
 
+      // AudioContext must be resumed after the document received a user gesture to enable audio playback.
+      audioCtx.resume();
+
       var xhr = new XMLHttpRequest();
 
       xhr.onload = function() {


### PR DESCRIPTION
Due to upcoming [Autoplay policy changes](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes), an AudioContext must be created or resumed after the document received a user gesture to enable audio playback.

More at https://webaudio.github.io/web-audio-api/#dfn-allowed-to-start

_/me excited to contribute to this essential PWA ;)_